### PR TITLE
ci: bump Xcode 16.0 -> 16.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Select Xcode 16
-        run: sudo xcode-select -s /Applications/Xcode_16.0.app
+        run: sudo xcode-select -s /Applications/Xcode_16.1.app
 
       - name: Install build dependencies
         run: |


### PR DESCRIPTION
Xcode 16.0 has been removed from GitHub Actions runners.