### PR TITLE
Fix rootless export of repositories

### DIFF
--- a/twackup-cli/src/commands/backup/package_manager/cydia.rs
+++ b/twackup-cli/src/commands/backup/package_manager/cydia.rs
@@ -18,7 +18,7 @@
  */
 
 use super::{Hooks, OldStylePackageManager, PackageManagerDescription};
-use crate::{commands::backup::RepoGroup, Result};
+use crate::{commands::backup::RepoGroup, paths, Result};
 use plist::Value as PValue;
 use std::{io, path::PathBuf};
 use twackup::repository::Repository;
@@ -65,7 +65,8 @@ impl Cydia {
 
 impl Hooks for Cydia {
     fn post_import(&self, repo_group: &RepoGroup) -> Result<()> {
-        let mut prefs = PValue::from_file(self.prefs_path)?;
+        let prefs_path = paths::jb_root_path(self.prefs_path);
+        let mut prefs = PValue::from_file(&prefs_path)?;
 
         let prefs_dict = prefs
             .as_dictionary_mut()
@@ -82,7 +83,7 @@ impl Hooks for Cydia {
 
         prefs_dict.insert("CydiaSources".to_string(), PValue::Dictionary(sources));
 
-        Ok(prefs.to_file_binary(self.prefs_path)?)
+        Ok(prefs.to_file_binary(prefs_path)?)
     }
 }
 
@@ -94,6 +95,6 @@ impl PackageManagerDescription for Cydia {
     }
 
     fn repos_file_path(&self) -> PathBuf {
-        PathBuf::from(self.sources)
+        paths::jb_root_path(self.sources)
     }
 }

--- a/twackup-cli/src/commands/backup/package_manager/sileo.rs
+++ b/twackup-cli/src/commands/backup/package_manager/sileo.rs
@@ -18,7 +18,7 @@
  */
 
 use super::{Hooks, NewStylePackageManager, PackageManagerDescription};
-use crate::{commands::backup::RepoGroup, Result};
+use crate::{commands::backup::RepoGroup, paths, Result};
 use std::path::PathBuf;
 
 pub(crate) struct Sileo {
@@ -47,7 +47,7 @@ impl PackageManagerDescription for Sileo {
     }
 
     fn repos_file_path(&self) -> PathBuf {
-        PathBuf::from(self.sources)
+        paths::jb_root_path(self.sources)
     }
 }
 

--- a/twackup-cli/src/commands/backup/package_manager/zebra.rs
+++ b/twackup-cli/src/commands/backup/package_manager/zebra.rs
@@ -18,7 +18,7 @@
  */
 
 use super::{Hooks, OldStylePackageManager, PackageManagerDescription};
-use crate::{commands::backup::RepoGroup, Result};
+use crate::{commands::backup::RepoGroup, paths, Result};
 use std::{fs, path::PathBuf};
 
 pub(crate) struct Zebra {
@@ -37,7 +37,8 @@ impl Zebra {
 
 impl Hooks for Zebra {
     fn post_import(&self, _repo_group: &RepoGroup) -> Result<()> {
-        let path = "/var/mobile/Library/Application Support/xyz.willy.Zebra/zebra.db";
+        let path =
+            paths::jb_root_path("/var/mobile/Library/Application Support/xyz.willy.Zebra/zebra.db");
         fs::remove_file(path)?;
 
         Ok(())
@@ -52,6 +53,6 @@ impl PackageManagerDescription for Zebra {
     }
 
     fn repos_file_path(&self) -> PathBuf {
-        PathBuf::from(self.sources)
+        paths::jb_root_path(self.sources)
     }
 }

--- a/twackup-cli/src/main.rs
+++ b/twackup-cli/src/main.rs
@@ -93,7 +93,7 @@ async fn _run() -> Result<()> {
         Command::Import(cmd) => cmd.run().await,
 
         Command::ShowLicense => {
-            let license = fs::read_to_string(paths::LICENSE_PATH)?;
+            let license = fs::read_to_string(paths::jb_root_path(paths::LICENSE_PATH))?;
             eprintln!("\n{license}\n");
 
             Ok(())

--- a/twackup-cli/src/paths.rs
+++ b/twackup-cli/src/paths.rs
@@ -1,4 +1,4 @@
-use std::ffi::OsString;
+use std::{ffi::OsString, path::PathBuf};
 
 pub(crate) const LICENSE_PATH: &str = "/usr/share/doc/ru.danpashin.twackup/LICENSE";
 
@@ -22,6 +22,29 @@ pub(crate) fn dpkg_admin_dir() -> &'static str {
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 pub(crate) fn dpkg_admin_dir() -> OsString {
     "/var/lib/dpkg".into()
+}
+
+#[cfg(target_os = "ios")]
+pub(crate) fn jb_root_path(path: &str) -> PathBuf {
+    let rootful_path = PathBuf::from(path);
+    if std::fs::metadata(&rootful_path).is_ok() {
+        return rootful_path;
+    }
+
+    let relative_path = std::path::Path::new(path)
+        .strip_prefix("/")
+        .unwrap_or_else(|_| std::path::Path::new(path));
+    let rootless_path = std::path::Path::new("/var/jb").join(relative_path);
+    if std::fs::metadata(&rootless_path).is_ok() {
+        rootless_path
+    } else {
+        rootful_path
+    }
+}
+
+#[cfg(not(target_os = "ios"))]
+pub(crate) fn jb_root_path(path: &str) -> PathBuf {
+    PathBuf::from(path)
 }
 
 #[cfg(target_os = "ios")]


### PR DESCRIPTION
* Add `jb_root_path` helper imitating interface from twackup-gui
    * Handrolls path detection to imitate existing code in paths.rs (vs adding libroot dependency)
* Fix package manager paths in rootless
* Fix LICENSE_PATH in rootless